### PR TITLE
UOELSA-513: Do not update tyoskentelyjakso after submit

### DIFF
--- a/src/views/muokkaa-tyoskentelyjaksoa.vue
+++ b/src/views/muokkaa-tyoskentelyjaksoa.vue
@@ -81,14 +81,13 @@
         data.addedFiles.forEach((file: File) => formData.append('files', file, file.name))
         formData.append('deletedAsiakirjaIdsJson', JSON.stringify(data.deletedAsiakirjaIds))
 
-        this.tyoskentelyjakso = (
-          await axios.put('erikoistuva-laakari/tyoskentelyjaksot', formData, {
-            headers: {
-              'Content-Type': 'multipart/form-data'
-            },
-            timeout: 120000
-          })
-        ).data
+        await axios.put('erikoistuva-laakari/tyoskentelyjaksot', formData, {
+          headers: {
+            'Content-Type': 'multipart/form-data'
+          },
+          timeout: 120000
+        })
+
         toastSuccess(this, this.$t('tyoskentelyjakson-tallentaminen-onnistui'))
         this.skipRouteExitConfirm = true
         this.$router.push({


### PR DESCRIPTION
- Do not update tyoskentelyjakso after data is submitted to prevent duplicate items in list. There is no need for update as next route is pushed to router immediately after PUT