### PR TITLE
UOELSA-455: Lisää await kun työskentelyjaksoa päivitetään

### DIFF
--- a/src/views/tyoskentelyjaksot/muokkaa-tyoskentelyjaksoa.vue
+++ b/src/views/tyoskentelyjaksot/muokkaa-tyoskentelyjaksoa.vue
@@ -98,7 +98,7 @@
         data.addedFiles.forEach((file: File) => formData.append('files', file, file.name))
         formData.append('deletedAsiakirjaIdsJson', JSON.stringify(data.deletedAsiakirjaIds))
 
-        putTyoskentelyjakso(formData)
+        await putTyoskentelyjakso(formData)
 
         toastSuccess(this, this.$t('tyoskentelyjakson-tallentaminen-onnistui'))
         this.skipRouteExitConfirm = true


### PR DESCRIPTION
- Lisätyt tiedostot eivät muuten ehdi latautua palvelimelle eivätkä tule näkyviin heti muokkauksen jälkeen vaan vasta kun sivu ladataan uudelleen