### PR TITLE
UOELSA-558: Vaihda otsikko ja hakukentän placeholder

### DIFF
--- a/src/components/arvioinnit-list/arvioinnit-list.vue
+++ b/src/components/arvioinnit-list/arvioinnit-list.vue
@@ -4,11 +4,11 @@
     <b-container fluid>
       <b-row lg>
         <b-col>
-          <h1>{{ $t('suoritusarvioinnit') }}</h1>
+          <h1>{{ $t('arvioinnit') }}</h1>
           <search-input
             class="mb-4"
             :hakutermi.sync="hakutermi"
-            :placeholder="$t('hae-suoritusarviointeja')"
+            :placeholder="$t('hae-tapahtuman-nimella')"
           />
         </b-col>
       </b-row>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -105,7 +105,7 @@
   "fi": "suomi",
   "hae-asiakirjoja": "Hae asiakirjoja...",
   "hae-erikoistuvan-nimella": "Hae erikoistuvan nimellä...",
-  "hae-suoritusarviointeja": "Hae suoritusarviointeja...",
+  "hae-tapahtuman-nimella": "Hae tapahtuman nimellä...",
   "haluatko-varmasti-poistaa": "Haluatko varmasti poistaa {name}?",
   "helppo": "Helppo",
   "henkilotiedot": "Henkilötiedot",


### PR DESCRIPTION
- Sprint review:ssä sovittiin, että otsikoksi vaihdetaan 'Arvioinnit' ja hakukentän placeholderiksi 'Hae tapahtuman nimellä'