### PR TITLE
UOELSA-715: Korjaa RoleSpecificRoute -komponentti

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -107,7 +107,8 @@ const routes: Array<RouteConfig> = [
         component: RoleSpecificRoute,
         props: {
           routeComponent: MuokkaaKoulutussuunnitelma,
-          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari]
+          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari],
+          confirmRouteExit: true
         }
       },
       {
@@ -125,7 +126,8 @@ const routes: Array<RouteConfig> = [
         component: RoleSpecificRoute,
         props: {
           routeComponent: UusiSuoritemerkinta,
-          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari]
+          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari],
+          confirmRouteExit: true
         }
       },
       {
@@ -134,7 +136,8 @@ const routes: Array<RouteConfig> = [
         component: RoleSpecificRoute,
         props: {
           routeComponent: MuokkaaSuoritemerkintaa,
-          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari]
+          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari],
+          confirmRouteExit: true
         }
       },
       {
@@ -165,7 +168,8 @@ const routes: Array<RouteConfig> = [
         component: RoleSpecificRoute,
         props: {
           routeComponent: Arviointipyynto,
-          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari]
+          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari],
+          confirmRouteExit: true
         }
       },
       {
@@ -192,7 +196,8 @@ const routes: Array<RouteConfig> = [
         component: RoleSpecificRoute,
         props: {
           routeComponent: Itsearviointi,
-          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari]
+          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari],
+          confirmRouteExit: true
         }
       },
       {
@@ -223,7 +228,8 @@ const routes: Array<RouteConfig> = [
         component: RoleSpecificRoute,
         props: {
           routeComponent: MuokkaaArviointia,
-          allowedRoles: [ELSA_ROLE.Kouluttaja, ELSA_ROLE.Vastuuhenkilo]
+          allowedRoles: [ELSA_ROLE.Kouluttaja, ELSA_ROLE.Vastuuhenkilo],
+          confirmRouteExit: true
         }
       },
       {
@@ -241,7 +247,8 @@ const routes: Array<RouteConfig> = [
         component: RoleSpecificRoute,
         props: {
           routeComponent: UusiTyoskentelyjakso,
-          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari]
+          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari],
+          confirmRouteExit: true
         }
       },
       {
@@ -259,7 +266,8 @@ const routes: Array<RouteConfig> = [
         component: RoleSpecificRoute,
         props: {
           routeComponent: MuokkaaTyoskentelyjaksoa,
-          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari]
+          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari],
+          confirmRouteExit: true
         }
       },
       {
@@ -268,7 +276,8 @@ const routes: Array<RouteConfig> = [
         component: RoleSpecificRoute,
         props: {
           routeComponent: UusiPoissaolo,
-          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari]
+          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari],
+          confirmRouteExit: true
         }
       },
       {
@@ -286,7 +295,8 @@ const routes: Array<RouteConfig> = [
         component: RoleSpecificRoute,
         props: {
           routeComponent: MuokkaaPoissaoloa,
-          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari]
+          allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari],
+          confirmRouteExit: true
         }
       },
       {
@@ -344,7 +354,8 @@ const routes: Array<RouteConfig> = [
             component: RoleSpecificRoute,
             props: {
               routeComponent: ErikoistuvaKoulutussopimus,
-              allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari]
+              allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari],
+              confirmRouteExit: true
             }
           },
           {
@@ -353,7 +364,8 @@ const routes: Array<RouteConfig> = [
             component: RoleSpecificRoute,
             props: {
               routeComponent: ErikoistuvaArviointilomakeAloituskeskustelu,
-              allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari]
+              allowedRoles: [ELSA_ROLE.ErikoistuvaLaakari],
+              confirmRouteExit: true
             }
           },
           {
@@ -398,7 +410,8 @@ const routes: Array<RouteConfig> = [
             component: RoleSpecificRoute,
             props: {
               routeComponent: Koulutussopimus,
-              allowedRoles: [ELSA_ROLE.Kouluttaja, ELSA_ROLE.Vastuuhenkilo]
+              allowedRoles: [ELSA_ROLE.Kouluttaja, ELSA_ROLE.Vastuuhenkilo],
+              confirmRouteExit: true
             }
           },
           {
@@ -407,7 +420,8 @@ const routes: Array<RouteConfig> = [
             component: RoleSpecificRoute,
             props: {
               routeComponent: KouluttajaArviointilomakeAloituskeskustelu,
-              allowedRoles: [ELSA_ROLE.Kouluttaja]
+              allowedRoles: [ELSA_ROLE.Kouluttaja],
+              confirmRouteExit: true
             }
           },
           {

--- a/src/router/role-specific-route.vue
+++ b/src/router/role-specific-route.vue
@@ -1,6 +1,10 @@
 <template>
   <div v-if="!loading">
-    <component :is="routeComponent" v-if="isAllowedRoute" />
+    <component
+      :is="routeComponent"
+      v-if="isAllowedRoute"
+      @skipRouteExitConfirm="onSkipRouteExitConfirm"
+    />
     <b-container v-else class="mt-4 mt-md-5 mb-6 ml-2 ml-sm-5 ml-md-4">
       <page-not-found-content />
     </b-container>
@@ -11,22 +15,28 @@
 </template>
 
 <script lang="ts">
-  import { Component, Vue, Prop } from 'vue-property-decorator'
+  import { Component, Mixins, Prop, Watch } from 'vue-property-decorator'
 
+  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import store from '@/store'
   import PageNotFoundContent from '@/views/404/page-not-found-content.vue'
+
+  Component.registerHooks(['beforeRouteLeave'])
 
   @Component({
     components: {
       PageNotFoundContent
     }
   })
-  export default class ErikoistuvaRoute extends Vue {
+  export default class ErikoistuvaRoute extends Mixins(ConfirmRouteExit) {
     @Prop({ required: true })
     routeComponent!: any
 
     @Prop({ required: true, default: [] })
     allowedRoles!: string[]
+
+    @Prop({ required: false, type: Boolean, default: false })
+    confirmRouteExit!: boolean
 
     loading = true
 
@@ -35,7 +45,13 @@
       return this.allowedRoles.some((r) => authorities.includes(r))
     }
 
-    async mounted() {
+    onSkipRouteExitConfirm(val: boolean) {
+      this.skipRouteExitConfirm = val
+    }
+
+    @Watch('$route', { immediate: true, deep: true })
+    async onUrlChange() {
+      this.skipRouteExitConfirm = !this.confirmRouteExit
       await store.dispatch('auth/authorize')
       this.loading = false
     }

--- a/src/views/arvioinnit/arviointipyynto.vue
+++ b/src/views/arvioinnit/arviointipyynto.vue
@@ -33,10 +33,9 @@
 <script lang="ts">
   import axios from 'axios'
   import { formatISO } from 'date-fns'
-  import { Component, Mixins } from 'vue-property-decorator'
+  import { Component, Vue } from 'vue-property-decorator'
 
   import ArviointipyyntoForm from '@/forms/arviointipyynto-form.vue'
-  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import { ArviointipyyntoLomake, Suoritusarviointi } from '@/types'
   import { decorate } from '@/utils/arvioinninAntajaListDecorator'
   import { confirmDelete } from '@/utils/confirm'
@@ -49,7 +48,7 @@
       ArviointipyyntoForm
     }
   })
-  export default class Arviointipyynto extends Mixins(ConfirmRouteExit) {
+  export default class Arviointipyynto extends Vue {
     items = [
       {
         text: this.$t('etusivu'),
@@ -116,7 +115,7 @@
             lisatiedot: value.lisatiedot
           })
           toastSuccess(this, this.$t('arviointipyynnon-tallentaminen-onnistui'))
-          this.skipRouteExitConfirm = true
+          this.$emit('skipRouteExitConfirm', true)
           this.$router.push({
             name: 'arvioinnit'
           })
@@ -128,7 +127,7 @@
           const arviointipyynto = (
             await axios.post('erikoistuva-laakari/suoritusarvioinnit/arviointipyynto', value)
           ).data
-          this.skipRouteExitConfirm = true
+          this.$emit('skipRouteExitConfirm', true)
           this.$router.push({
             name: 'arviointipyynto-lahetetty',
             params: { arviointiId: `${arviointipyynto.id}` }
@@ -152,7 +151,7 @@
         try {
           await axios.delete(`erikoistuva-laakari/suoritusarvioinnit/${this.arviointipyynto?.id}`)
           toastSuccess(this, this.$t('arviointipyynto-poistettu-onnistuneesti'))
-          this.skipRouteExitConfirm = true
+          this.$emit('skipRouteExitConfirm', true)
           this.$router.push({
             name: 'arvioinnit'
           })

--- a/src/views/arvioinnit/itsearviointi.vue
+++ b/src/views/arvioinnit/itsearviointi.vue
@@ -25,10 +25,9 @@
 
 <script lang="ts">
   import axios from 'axios'
-  import { Component, Mixins } from 'vue-property-decorator'
+  import { Component, Vue } from 'vue-property-decorator'
 
   import ArviointiForm from '@/forms/arviointi-form.vue'
-  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import { toastFail, toastSuccess } from '@/utils/toast'
 
   @Component({
@@ -36,7 +35,7 @@
       ArviointiForm
     }
   })
-  export default class Itsearviointi extends Mixins(ConfirmRouteExit) {
+  export default class Itsearviointi extends Vue {
     value = null
     items = [
       {
@@ -68,7 +67,7 @@
       try {
         await axios.put('erikoistuva-laakari/suoritusarvioinnit', value)
         toastSuccess(this, this.$t('itsearvioinnin-tallentaminen-onnistui'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
         this.$router.push({
           name: 'arviointi',
           params: { arviointiId: this.$route.params.arviointiId }

--- a/src/views/arvioinnit/muokkaa-arviointia.vue
+++ b/src/views/arvioinnit/muokkaa-arviointia.vue
@@ -25,10 +25,9 @@
 
 <script lang="ts">
   import axios from 'axios'
-  import { Component, Mixins } from 'vue-property-decorator'
+  import { Component, Vue } from 'vue-property-decorator'
 
   import ArviointiForm from '@/forms/arviointi-form.vue'
-  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import { resolveRolePath } from '@/utils/apiRolePathResolver'
   import { toastFail, toastSuccess } from '@/utils/toast'
 
@@ -37,7 +36,7 @@
       ArviointiForm
     }
   })
-  export default class MuokkaaArviointia extends Mixins(ConfirmRouteExit) {
+  export default class MuokkaaArviointia extends Vue {
     value = null
     items = [
       {
@@ -69,7 +68,7 @@
       try {
         await axios.put(`${resolveRolePath()}/suoritusarvioinnit`, value)
         toastSuccess(this, this.$t('arvioinnin-tallentaminen-onnistui'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
         this.$router.push({
           name: 'arviointi',
           params: { arviointiId: this.$route.params.arviointiId }

--- a/src/views/koejakso/erikoistuva/arviointilomake-aloituskeskustelu/arviointilomake-aloituskeskustelu.vue
+++ b/src/views/koejakso/erikoistuva/arviointilomake-aloituskeskustelu/arviointilomake-aloituskeskustelu.vue
@@ -86,11 +86,9 @@
 </template>
 
 <script lang="ts">
-  import Component from 'vue-class-component'
-  import { Mixins } from 'vue-property-decorator'
+  import { Component, Vue } from 'vue-property-decorator'
 
   import ErikoistuvaDetails from '@/components/erikoistuva-details/erikoistuva-details.vue'
-  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import store from '@/store'
   import { AloituskeskusteluLomake, Koejakso, KoejaksonVaiheButtonStates } from '@/types'
   import { LomakeTilat } from '@/utils/constants'
@@ -106,9 +104,7 @@
       ArviointilomakeAloituskeskusteluReadonly
     }
   })
-  export default class ErikoistuvaArviointilomakeAloituskeskustelu extends Mixins(
-    ConfirmRouteExit
-  ) {
+  export default class ErikoistuvaArviointilomakeAloituskeskustelu extends Vue {
     items = [
       {
         text: this.$t('etusivu'),
@@ -174,7 +170,7 @@
         this.aloituskeskusteluLomake = this.koejaksoData.aloituskeskustelu
       }
       if (!this.editable) {
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
       }
     }
 
@@ -194,7 +190,7 @@
         }
 
         toastSuccess(this, this.$t('aloituskeskustelu-tallennettu-onnistuneesti'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
         checkCurrentRouteAndRedirect(this.$router, '/koejakso')
       } catch (err) {
         toastFail(this, this.$t('aloituskeskustelu-tallennus-epaonnistui'))
@@ -206,7 +202,7 @@
       try {
         await store.dispatch('erikoistuva/postAloituskeskustelu', this.aloituskeskusteluLomake)
         toastSuccess(this, this.$t('aloituskeskustelu-lisatty-onnistuneesti'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
       } catch (err) {
         toastFail(this, this.$t('aloituskeskustelu-lisaaminen-epaonnistui'))
       }
@@ -216,7 +212,7 @@
       try {
         await store.dispatch('erikoistuva/putAloituskeskustelu', this.aloituskeskusteluLomake)
         toastSuccess(this, this.$t('aloituskeskustelu-lisatty-onnistuneesti'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
       } catch (err) {
         toastFail(this, this.$t('aloituskeskustelu-lisaaminen-epaonnistui'))
       }
@@ -240,7 +236,7 @@
 
     watch() {
       if (!this.editable) {
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
       }
     }
 
@@ -253,7 +249,7 @@
       this.setKoejaksoData()
       this.loading = false
       if (!this.editable) {
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
       }
     }
   }

--- a/src/views/koejakso/erikoistuva/koulutussopimus/koulutussopimus.vue
+++ b/src/views/koejakso/erikoistuva/koulutussopimus/koulutussopimus.vue
@@ -95,11 +95,10 @@
 
 <script lang="ts">
   import Component from 'vue-class-component'
-  import { Mixins } from 'vue-property-decorator'
+  import { Vue } from 'vue-property-decorator'
 
   import { getKoulutussopimusLomake } from '@/api/erikoistuva'
   import ErikoistuvaDetails from '@/components/erikoistuva-details/erikoistuva-details.vue'
-  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import store from '@/store'
   import { KoulutussopimusLomake, Koejakso, KoejaksonVaiheButtonStates } from '@/types'
   import { LomakeTilat } from '@/utils/constants'
@@ -115,7 +114,7 @@
       KoulutussopimusReadonly
     }
   })
-  export default class ErikoistuvaKoulutussopimus extends Mixins(ConfirmRouteExit) {
+  export default class ErikoistuvaKoulutussopimus extends Vue {
     items = [
       {
         text: this.$t('etusivu'),
@@ -186,7 +185,7 @@
       }
 
       if (!this.editable) {
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
       }
     }
 
@@ -205,7 +204,7 @@
         }
 
         toastSuccess(this, this.$t('koulutussopimus-tallennettu-onnistuneesti'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
         checkCurrentRouteAndRedirect(this.$router, '/koejakso')
       } catch (err) {
         toastFail(this, this.$t('koulutussopimuksen-tallennus-epaonnistui'))
@@ -217,7 +216,7 @@
       try {
         await store.dispatch('erikoistuva/postKoulutussopimus', this.koulutussopimusLomake)
         toastSuccess(this, this.$t('koulutussopimus-lisatty-onnistuneesti'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
       } catch (err) {
         toastFail(this, this.$t('koulutussopimuksen-lisaaminen-epaonnistui'))
       }
@@ -227,7 +226,7 @@
       try {
         await store.dispatch('erikoistuva/putKoulutussopimus', this.koulutussopimusLomake)
         toastSuccess(this, this.$t('koulutussopimus-lisatty-onnistuneesti'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
       } catch (err) {
         toastFail(this, this.$t('koulutussopimuksen-lisaaminen-epaonnistui'))
       }
@@ -251,7 +250,7 @@
 
     watch() {
       if (!this.editable) {
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
       }
     }
 
@@ -274,7 +273,7 @@
       this.loading = false
 
       if (!this.editable) {
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
       }
     }
   }

--- a/src/views/koejakso/kouluttaja-vastuuhenkilo/koulutussopimus.vue
+++ b/src/views/koejakso/kouluttaja-vastuuhenkilo/koulutussopimus.vue
@@ -219,7 +219,6 @@
   import KoejaksonVaiheAllekirjoitukset from '@/components/koejakson-vaiheet/koejakson-vaihe-allekirjoitukset.vue'
   import ElsaConfirmationModal from '@/components/modal/confirmation-modal.vue'
   import ElsaReturnToSenderModal from '@/components/modal/return-to-sender-modal.vue'
-  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import store from '@/store'
   import {
     KoejaksonVaiheAllekirjoitus,
@@ -254,7 +253,7 @@
       }
     }
   })
-  export default class Koulutussopimus extends Mixins(ConfirmRouteExit, validationMixin) {
+  export default class Koulutussopimus extends Mixins(validationMixin) {
     skipRouteExitConfirm!: boolean
     $refs!: {
       kouluttajaKoulutussopimusForm: any
@@ -401,7 +400,7 @@
         this.buttonStates.secondaryButtonLoading = true
         await store.dispatch(`${resolveRolePath()}/putKoulutussopimus`, form)
         this.buttonStates.secondaryButtonLoading = false
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
         checkCurrentRouteAndRedirect(this.$router, '/koejakso')
         toastSuccess(this, this.$t('koulutussopimus-palautettu-onnistuneesti'))
       } catch (err) {
@@ -410,7 +409,7 @@
     }
 
     async updateSentForm() {
-      this.skipRouteExitConfirm = true
+      this.$emit('skipRouteExitConfirm', true)
       try {
         this.buttonStates.primaryButtonLoading = true
         await store.dispatch(`${resolveRolePath()}/putKoulutussopimus`, this.form)
@@ -461,7 +460,7 @@
       this.loading = false
 
       if (!this.editable || this.returned) {
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
       }
     }
 

--- a/src/views/koejakso/kouluttaja/arviointilomake-aloituskeskustelu/kouluttaja-arviointilomake-aloituskeskustelu.vue
+++ b/src/views/koejakso/kouluttaja/arviointilomake-aloituskeskustelu/kouluttaja-arviointilomake-aloituskeskustelu.vue
@@ -171,7 +171,7 @@
   import { format } from 'date-fns'
   import _get from 'lodash/get'
   import Component from 'vue-class-component'
-  import { Mixins } from 'vue-property-decorator'
+  import { Vue } from 'vue-property-decorator'
 
   import * as api from '@/api/kouluttaja'
   import ElsaButton from '@/components/button/button.vue'
@@ -181,7 +181,6 @@
   import KoulutuspaikanArvioijat from '@/components/koejakson-vaiheet/koulutuspaikan-arvioijat.vue'
   import ElsaConfirmationModal from '@/components/modal/confirmation-modal.vue'
   import ElsaReturnToSenderModal from '@/components/modal/return-to-sender-modal.vue'
-  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import store from '@/store'
   import {
     KoejaksonVaiheAllekirjoitus,
@@ -204,7 +203,7 @@
       KoulutuspaikanArvioijat
     }
   })
-  export default class KouluttajaArviointilomakeAloituskeskustelu extends Mixins(ConfirmRouteExit) {
+  export default class KouluttajaArviointilomakeAloituskeskustelu extends Vue {
     items = [
       {
         text: this.$t('etusivu'),
@@ -334,7 +333,7 @@
         this.buttonStates.secondaryButtonLoading = true
         await store.dispatch('kouluttaja/putAloituskeskustelu', form)
         this.buttonStates.secondaryButtonLoading = false
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
         checkCurrentRouteAndRedirect(this.$router, '/koejakso')
         toastSuccess(this, this.$t('aloituskeskustelu-palautettu-erikoistuvalle-muokattavaksi'))
       } catch (err) {
@@ -362,7 +361,7 @@
         this.buttonStates.primaryButtonLoading = true
         await store.dispatch('kouluttaja/putAloituskeskustelu', form)
         this.buttonStates.primaryButtonLoading = false
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
         checkCurrentRouteAndRedirect(this.$router, '/koejakso')
         toastSuccess(this, this.$t('aloituskeskustelu-lisatty-onnistuneesti'))
       } catch (err) {
@@ -378,7 +377,7 @@
       this.loading = false
 
       if (!this.editable || this.returned) {
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
       }
     }
   }

--- a/src/views/koulutussuunnitelma/muokkaa-koulutussuunnitelma.vue
+++ b/src/views/koulutussuunnitelma/muokkaa-koulutussuunnitelma.vue
@@ -42,13 +42,12 @@
 
 <script lang="ts">
   import axios from 'axios'
-  import { Component, Mixins } from 'vue-property-decorator'
+  import { Component, Vue } from 'vue-property-decorator'
 
   import { putKoulutussuunnitelma } from '@/api/erikoistuva'
   import ElsaButton from '@/components/button/button.vue'
   import ElsaErrorMessage from '@/components/error-message/error-message.vue'
   import KoulutussuunnitelmaForm from '@/forms/koulutussuunnitelma-form.vue'
-  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import { Koulutussuunnitelma } from '@/types'
   import { toastFail, toastSuccess } from '@/utils/toast'
 
@@ -59,7 +58,7 @@
       KoulutussuunnitelmaForm
     }
   })
-  export default class MuokkaaKoulutussuunnitelma extends Mixins(ConfirmRouteExit) {
+  export default class MuokkaaKoulutussuunnitelma extends Vue {
     items = [
       {
         text: this.$t('etusivu'),
@@ -101,7 +100,7 @@
       try {
         await putKoulutussuunnitelma(data)
         toastSuccess(this, this.$t('koulutussuunnitelman-tallentaminen-onnistui'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
         this.$router.push({
           name: 'koulutussuunnitelma'
         })

--- a/src/views/poissaolot/muokkaa-poissaoloa.vue
+++ b/src/views/poissaolot/muokkaa-poissaoloa.vue
@@ -25,10 +25,9 @@
 
 <script lang="ts">
   import axios from 'axios'
-  import { Component, Mixins } from 'vue-property-decorator'
+  import { Component, Vue } from 'vue-property-decorator'
 
   import PoissaoloForm from '@/forms/poissaolo-form.vue'
-  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import { PoissaoloLomake } from '@/types'
   import { confirmDelete } from '@/utils/confirm'
   import { ErrorKeys } from '@/utils/constants'
@@ -40,7 +39,7 @@
       PoissaoloForm
     }
   })
-  export default class MuokkaaPoissaoloa extends Mixins(ConfirmRouteExit) {
+  export default class MuokkaaPoissaoloa extends Vue {
     items = [
       {
         text: this.$t('etusivu'),
@@ -92,7 +91,7 @@
           await axios.put('erikoistuva-laakari/tyoskentelyjaksot/poissaolot', value)
         ).data
         toastSuccess(this, this.$t('poissaolon-tallentaminen-onnistui'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
         this.$router.push({
           name: 'poissaolo',
           params: {
@@ -128,7 +127,7 @@
             `erikoistuva-laakari/tyoskentelyjaksot/poissaolot/${this.poissaolo.id}`
           )
           toastSuccess(this, this.$t('poissaolo-poistettu-onnistuneesti'))
-          this.skipRouteExitConfirm = true
+          this.$emit('skipRouteExitConfirm', true)
           this.$router.push({
             name: 'tyoskentelyjaksot'
           })

--- a/src/views/poissaolot/uusi-poissaolo.vue
+++ b/src/views/poissaolot/uusi-poissaolo.vue
@@ -23,10 +23,9 @@
 
 <script lang="ts">
   import axios from 'axios'
-  import { Component, Mixins } from 'vue-property-decorator'
+  import { Component, Vue } from 'vue-property-decorator'
 
   import PoissaoloForm from '@/forms/poissaolo-form.vue'
-  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import { PoissaoloLomake } from '@/types'
   import { toastFail, toastSuccess } from '@/utils/toast'
 
@@ -35,7 +34,7 @@
       PoissaoloForm
     }
   })
-  export default class UusiPoissaolo extends Mixins(ConfirmRouteExit) {
+  export default class UusiPoissaolo extends Vue {
     items = [
       {
         text: this.$t('etusivu'),
@@ -74,7 +73,7 @@
           await axios.post('erikoistuva-laakari/tyoskentelyjaksot/poissaolot', value)
         ).data
         toastSuccess(this, this.$t('poissaolo-lisatty-onnistuneesti'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
         this.$router.push({
           name: 'poissaolo',
           params: {

--- a/src/views/suoritemerkinnat/muokkaa-suoritemerkintaa.vue
+++ b/src/views/suoritemerkinnat/muokkaa-suoritemerkintaa.vue
@@ -27,10 +27,9 @@
 
 <script lang="ts">
   import axios from 'axios'
-  import { Component, Mixins } from 'vue-property-decorator'
+  import { Component, Vue } from 'vue-property-decorator'
 
   import SuoritemerkintaForm from '@/forms/suoritemerkinta-form.vue'
-  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import { SuoritemerkintaLomake } from '@/types'
   import { confirmDelete } from '@/utils/confirm'
   import { toastFail, toastSuccess } from '@/utils/toast'
@@ -41,7 +40,7 @@
       SuoritemerkintaForm
     }
   })
-  export default class MuokkaaSuoritemerkintaa extends Mixins(ConfirmRouteExit) {
+  export default class MuokkaaSuoritemerkintaa extends Vue {
     items = [
       {
         text: this.$t('etusivu'),
@@ -103,7 +102,7 @@
           })
         ).data
         toastSuccess(this, this.$t('suoritemerkinnan-tallentaminen-onnistui'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
         this.$router.push({
           name: 'suoritemerkinta',
           params: {
@@ -128,7 +127,7 @@
         try {
           await axios.delete(`erikoistuva-laakari/suoritemerkinnat/${this.suoritemerkinta.id}`)
           toastSuccess(this, this.$t('suoritemerkinta-poistettu-onnistuneesti'))
-          this.skipRouteExitConfirm = true
+          this.$emit('skipRouteExitConfirm', true)
           this.$router.push({
             name: 'suoritemerkinnat'
           })

--- a/src/views/suoritemerkinnat/uusi-suoritemerkinta.vue
+++ b/src/views/suoritemerkinnat/uusi-suoritemerkinta.vue
@@ -25,10 +25,9 @@
 
 <script lang="ts">
   import axios from 'axios'
-  import { Component, Mixins } from 'vue-property-decorator'
+  import { Component, Vue } from 'vue-property-decorator'
 
   import SuoritemerkintaForm from '@/forms/suoritemerkinta-form.vue'
-  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import { Suoritemerkinta, SuoritemerkintaLomake } from '@/types'
   import { toastFail, toastSuccess } from '@/utils/toast'
 
@@ -37,7 +36,7 @@
       SuoritemerkintaForm
     }
   })
-  export default class UusiSuoritemerkinta extends Mixins(ConfirmRouteExit) {
+  export default class UusiSuoritemerkinta extends Vue {
     items = [
       {
         text: this.$t('etusivu'),
@@ -78,7 +77,7 @@
           await axios.post('erikoistuva-laakari/suoritemerkinnat', value)
         ).data
         toastSuccess(this, this.$t('suoritusmerkinta-lisatty-onnistuneesti'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
         this.$router.push({
           name: 'suoritemerkinta',
           params: {

--- a/src/views/tyoskentelyjaksot/muokkaa-tyoskentelyjaksoa.vue
+++ b/src/views/tyoskentelyjaksot/muokkaa-tyoskentelyjaksoa.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script lang="ts">
-  import { Component, Mixins } from 'vue-property-decorator'
+  import { Component, Vue } from 'vue-property-decorator'
 
   import {
     getTyoskentelyjakso,
@@ -34,7 +34,6 @@
     putTyoskentelyjakso
   } from '@/api/erikoistuva'
   import TyoskentelyjaksoForm from '@/forms/tyoskentelyjakso-form.vue'
-  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import { Tyoskentelyjakso, TyoskentelyjaksoLomake } from '@/types'
   import { ErrorKeys } from '@/utils/constants'
   import { toastFail, toastSuccess } from '@/utils/toast'
@@ -44,7 +43,7 @@
       TyoskentelyjaksoForm
     }
   })
-  export default class MuokkaaTyoskentelyjaksoa extends Mixins(ConfirmRouteExit) {
+  export default class MuokkaaTyoskentelyjaksoa extends Vue {
     items = [
       {
         text: this.$t('etusivu'),
@@ -100,7 +99,7 @@
         await putTyoskentelyjakso(formData)
 
         toastSuccess(this, this.$t('tyoskentelyjakson-tallentaminen-onnistui'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
         this.$router.push({
           name: 'tyoskentelyjakso',
           params: {

--- a/src/views/tyoskentelyjaksot/uusi-tyoskentelyjakso.vue
+++ b/src/views/tyoskentelyjaksot/uusi-tyoskentelyjakso.vue
@@ -26,10 +26,9 @@
 
 <script lang="ts">
   import axios from 'axios'
-  import { Component, Mixins } from 'vue-property-decorator'
+  import { Component, Vue } from 'vue-property-decorator'
 
   import TyoskentelyjaksoForm from '@/forms/tyoskentelyjakso-form.vue'
-  import ConfirmRouteExit from '@/mixins/confirm-route-exit'
   import { TyoskentelyjaksoLomake } from '@/types'
   import { ErrorKeys } from '@/utils/constants'
   import { toastFail, toastSuccess } from '@/utils/toast'
@@ -39,7 +38,7 @@
       TyoskentelyjaksoForm
     }
   })
-  export default class UusiTyoskentelyjakso extends Mixins(ConfirmRouteExit) {
+  export default class UusiTyoskentelyjakso extends Vue {
     items = [
       {
         text: this.$t('etusivu'),
@@ -90,7 +89,7 @@
         ).data
 
         toastSuccess(this, this.$t('uusi-tyoskentelyjakso-lisatty'))
-        this.skipRouteExitConfirm = true
+        this.$emit('skipRouteExitConfirm', true)
         this.$router.push({
           name: 'tyoskentelyjakso',
           params: {


### PR DESCRIPTION
- Koska beforeRouteLeave hook toimii vain suoraan route componentissa mutta ei child componentissa, käytä ConfirmRouteExit mixiniä RoleSpecificRoute -komponentissa
- Välitä confirmExit propseina routerilta RoleSpecificRoutelle
- Välitä skipRouteExitConfirm eventti varsinaiselta sisältökomponentilta RoleSpecificRoutelle