### PR TITLE
UOELSA-783: Lisää accessKey api-kutsuihin testiympäristössä

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 
 import store from '@/store'
 import { OmatTiedotLomake } from '@/types'
+import { setCookie, getCookie } from '@/utils/cookies'
 import { wrapToFormData } from '@/utils/functions'
 
 export const ELSA_API_LOCATION =
@@ -12,6 +13,26 @@ export const ELSA_API_LOCATION =
     : ''
 axios.defaults.baseURL = `${ELSA_API_LOCATION}/api/`
 axios.defaults.withCredentials = true
+axios.interceptors.request.use((req) => {
+  if (window.location.hostname !== 'testi.elsapalvelu.fi') {
+    return req
+  }
+  let accessKey
+  const queryString = window.location.search
+  const urlParams = new URLSearchParams(queryString)
+  accessKey = urlParams.get('accessKey')
+  if (accessKey) {
+    setCookie('ACCESS-KEY', accessKey, 60 * 60 * 24 * 3650)
+  } else {
+    accessKey = getCookie('ACCESS-KEY')
+  }
+
+  if (accessKey) {
+    req.headers.common['X-Access-Key'] = accessKey
+  }
+
+  return req
+})
 axios.interceptors.response.use(
   (response) => {
     return response

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -1,0 +1,9 @@
+export function setCookie(name: string, value: string, maxAge: number) {
+  document.cookie = `${name}=${value}; max-age=${maxAge}`
+}
+
+export function getCookie(name: string) {
+  const value = `; ${document.cookie}`
+  const parts = value.split(`; ${name}=`) as string[] | undefined
+  return parts && parts.length === 2 ? parts?.pop()?.split(';').shift() : undefined
+}


### PR DESCRIPTION
- Tallenna query-parametrina annettu accessKey cookiehen ja aseta se X-Access-Key headeriin kaikkiin testiympäristössä tehtäviin api-kutsuihin