### PR TITLE
UOELSA-831: Korjaa jo käytettyjen tiedostonimien välittäminen asiakirjat-komponentille

### DIFF
--- a/src/components/asiakirjat/asiakirjat-content.vue
+++ b/src/components/asiakirjat/asiakirjat-content.vue
@@ -9,13 +9,10 @@
       <b-alert v-if="showInfoIfEmpty && rows === 0" variant="dark" class="mt-3" show>
         <font-awesome-icon icon="info-circle" fixed-width class="text-muted" />
         <span v-if="asiakirjat.length === 0">
-          {{ $t('ei-asiakirjoja') }}
-        </span>
-        <span v-else-if="noResultsInfoText === undefined">
-          {{ $t('ei-hakutuloksia') }}
+          {{ noResultsInfoText ? noResultsInfoText : $t('ei-asiakirjoja') }}
         </span>
         <span v-else>
-          {{ noResultsInfoText }}
+          {{ noSearchResultsInfoText ? noSearchResultsInfoText : $t('ei-hakutuloksia') }}
         </span>
       </b-alert>
     </div>
@@ -140,6 +137,9 @@
 
     @Prop({ required: false, type: String })
     noResultsInfoText?: string
+
+    @Prop({ required: false, type: String })
+    noSearchResultsInfoText?: string
 
     @Prop({ required: false, type: Boolean, default: false })
     loading!: boolean

--- a/src/forms/teoriakoulutus-form.vue
+++ b/src/forms/teoriakoulutus-form.vue
@@ -80,8 +80,8 @@
           <asiakirjat-upload
             :isPrimaryButton="false"
             :buttonText="$t('lisaa-liitetiedosto')"
-            :existing-file-names-for-current-view="existingFileNamesInCurrentView"
-            :existing-file-names-for-other-views="existingFileNamesInOtherViews"
+            :existingFileNamesInCurrentView="existingFileNamesInCurrentView"
+            :existingFileNamesInOtherViews="existingFileNamesInOtherViews"
             :disabled="reservedAsiakirjaNimetMutable === undefined"
             @selectedFiles="onFilesAdded"
           />
@@ -96,6 +96,7 @@
         </div>
       </template>
     </elsa-form-group>
+    <hr v-if="asiakirjatTableItems.length === 0" />
     <div class="d-flex flex-row-reverse flex-wrap">
       <elsa-button :loading="params.saving" type="submit" variant="primary" class="ml-2 mb-2">
         {{ $t('tallenna-teoriakoulutus') }}

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -120,7 +120,7 @@
   "edellinen": "Edellinen",
   "edistyminen-osaamistavoitteiden-mukaista": "Edistyminen on ollut sovittujen osaamistavoitteiden mukaista",
   "ei": "Ei",
-  "ei-asiakirjoja": "Asiakirjoja ei löytynyt",
+  "ei-asiakirjoja": "Ei asiakirjoja",
   "ei-hakutuloksia": "Ei hakutuloksia",
   "ei-huolenaiheita-on": "Ei, huolenaiheita on",
   "ei-koejaksoja": "Ei koejaksoja",

--- a/src/views/teoriakoulutukset/teoriakoulutus.vue
+++ b/src/views/teoriakoulutukset/teoriakoulutus.vue
@@ -54,12 +54,12 @@
                   :pagination-enabled="false"
                   :enable-search="false"
                   :enable-delete="false"
-                  :no-results-info-text="$t('ei-liitetiedostoja')"
+                  :noResultsInfoText="$t('ei-liitetiedostoja')"
                   :loading="loading"
                 />
               </template>
             </elsa-form-group>
-            <hr />
+            <hr v-if="teoriakoulutus.todistukset.length === 0" />
             <div class="d-flex flex-row-reverse flex-wrap">
               <elsa-button
                 :to="{ name: 'muokkaa-teoriakoulutusta' }"


### PR DESCRIPTION
- Lisää myös viiva ennen nappeja mikäli taulukko on tyhjä