### PR TITLE
UOELSA-856: Korjaa mobiilinavi

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -137,7 +137,7 @@
     right: 0;
     border-radius: 0.25rem 0 0 0;
     padding: 0.375rem 0.625rem 0.25rem 0.5rem;
-    z-index: 9999;
+    z-index: 1005;
   }
 
   .feedback-icon {

--- a/src/components/mobile-nav/mobile-nav.vue
+++ b/src/components/mobile-nav/mobile-nav.vue
@@ -165,18 +165,16 @@
 <style lang="scss" scoped>
   @import '~@/styles/variables';
 
+  $navbar-height: 53.5px;
+
   .mobile-menu {
-    top: auto;
+    z-index: 1010;
   }
 
   ::v-deep {
     .b-sidebar-right {
-      top: auto;
+      padding-top: $navbar-height;
       height: auto;
-    }
-
-    .b-sidebar-backdrop {
-      top: auto;
     }
   }
 

--- a/src/components/sidebar-menu/sidebar-menu.vue
+++ b/src/components/sidebar-menu/sidebar-menu.vue
@@ -101,17 +101,7 @@
   import Component from 'vue-class-component'
 
   @Component
-  export default class SidebarMenu extends Vue {
-    paddingTop = 64
-
-    // Tarkistetaan sivunavigaation paikka
-    mounted() {
-      const el = document.getElementById('navbar-top')
-      if (el) {
-        this.paddingTop = el.offsetHeight
-      }
-    }
-  }
+  export default class SidebarMenu extends Vue {}
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
- Aseta sivunaville top-paddingia mobiilissa ylänavin verran, koska top: auto; aiheuttaa sen, että navia ei pysty scrollaanaan loppuun saakka
- Aseta sivunaville pienempi z-index kuin ylänaville (tulee bootstrapvuen kautta .sticky-top classilla)
- Aseta kelluvalle palaute-elementille pienempi z-index, kuin sivunavilla mobiilissa, jolloin palautelinkki piilotetaan sivunavin ollessa auki, muutoin elementti menee kielenvalintalinkin päälle.
- Poista turha paddingin asettaminen sidebar-menu.vuen mountedissa