### PR TITLE
UOELSA-925: Päivitä axios ja ohjaa käyttäjä kirjaumissivulle

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@vue/cli": "^4.5.12",
     "@vue/composition-api": "^1.0.0-beta.21",
     "apexcharts": "^3.22.3",
-    "axios": "^0.21.2",
+    "axios": "^0.21.3",
     "bootstrap": "^4.5.2",
     "bootstrap-vue": "^2.17.0",
     "core-js": "^3.6.5",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -43,6 +43,7 @@ axios.interceptors.response.use(
       case 403:
         if (window.location.pathname !== '/kirjautuminen' && store.getters['auth/isLoggedIn']) {
           store.dispatch('auth/logout')
+          window.location.href = '/kirjautuminen'
         }
         break
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3085,10 +3085,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.21.2:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
-  integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
+axios@^0.21.3:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
 


### PR DESCRIPTION
- Axios 0.21.2:n bugi aiheuttaa sen että response interceptor ei triggeröidy ollenkaan mikäli myös request interceptoria on käytetty
- Ohjaa lisäksi käyttäjä kirjautumissivulle staten päivityksen jälkeen mikäli sessio ei ole enää voimassa