### PR TITLE
UOELSA-935: Poista viittaus erikoistuvaan

### DIFF
--- a/src/components/etusivu-cards/henkilotiedot-card.vue
+++ b/src/components/etusivu-cards/henkilotiedot-card.vue
@@ -3,7 +3,7 @@
     <div class="d-flex align-items-center">
       <div class="flex-fill">
         <user-avatar
-          :src-base64="avatar"
+          :src-base64="account.avatar"
           :imageSize="56"
           src-content-type="image/jpeg"
           :title="title"
@@ -49,13 +49,6 @@
   export default class HenkilotiedotCard extends Vue {
     get account() {
       return store.getters['auth/account']
-    }
-
-    get avatarSrc() {
-      if (this.account) {
-        return `data:image/jpeg;base64,${this.account.avatar}`
-      }
-      return undefined
     }
 
     get authorities() {

--- a/src/components/user-avatar/user-avatar.vue
+++ b/src/components/user-avatar/user-avatar.vue
@@ -48,8 +48,8 @@
     @Prop({ required: false, type: String })
     title?: string
 
-    @Prop({ required: false, type: String, default: '32' })
-    imageSize?: string
+    @Prop({ required: false, type: Number, default: 32 })
+    imageSize?: number
 
     get imageSrc() {
       if (this.srcContentType && this.srcBase64) {

--- a/src/components/vanha-asetus-varoitus/vanha-asetus-varoitus.vue
+++ b/src/components/vanha-asetus-varoitus/vanha-asetus-varoitus.vue
@@ -11,7 +11,9 @@
 
   import ElsaBadge from '@/components/badge/badge.vue'
   import store from '@/store'
+  import { Asetus, ErikoistuvaLaakari } from '@/types'
   import { vanhatAsetukset } from '@/utils/constants'
+  import { resolveOpintooikeusKaytossa } from '@/utils/opintooikeusResolver'
 
   @Component({
     components: {
@@ -25,13 +27,15 @@
       ) as string).toLowerCase()}</a>`
     }
 
-    get asetus() {
-      const opintooikeudet = store.getters['auth/account']?.erikoistuvaLaakari?.opintooikeudet
-      return opintooikeudet?.length > 0 ? opintooikeudet[0].asetus : null
+    get asetus(): Asetus | undefined {
+      const erikoistuvaLaakari = store.getters['auth/account']
+        ?.erikoistuvaLaakari as ErikoistuvaLaakari
+      const opintooikeusKaytossa = resolveOpintooikeusKaytossa(erikoistuvaLaakari)
+      return opintooikeusKaytossa?.asetus
     }
 
-    get vanhanAsetuksenMukainen() {
-      return vanhatAsetukset.includes(this.asetus.nimi)
+    get vanhanAsetuksenMukainen(): boolean {
+      return this.asetus?.nimi ? vanhatAsetukset.includes(this.asetus?.nimi) : false
     }
   }
 </script>

--- a/src/forms/seurantajakso-form.vue
+++ b/src/forms/seurantajakso-form.vue
@@ -20,10 +20,10 @@
         <div class="seurantajakso-erikoistuva-details">
           <erikoistuva-details
             :avatar="seurantajakso.erikoistuvanAvatar"
-            :name="seurantajakso.erikoistuvaLaakari.nimi"
-            :erikoisala="seurantajakso.erikoistuvaLaakari.erikoisalaNimi"
-            :opiskelijatunnus="seurantajakso.erikoistuvaLaakari.opiskelijatunnus"
-            :yliopisto="seurantajakso.erikoistuvaLaakari.yliopisto"
+            :name="seurantajakso.erikoistuvanNimi"
+            :erikoisala="seurantajakso.erikoistuvanErikoisalaNimi"
+            :opiskelijatunnus="seurantajakso.erikoistuvanOpiskelijatunnus"
+            :yliopisto="seurantajakso.erikoistuvanYliopistoNimi"
             :show-birthdate="false"
           ></erikoistuva-details>
           <elsa-form-group
@@ -959,7 +959,7 @@
     @Prop({ required: false, default: false })
     editing!: boolean
 
-    form: Seurantajakso = {
+    form: Partial<Seurantajakso> = {
       alkamispaiva: null,
       paattymispaiva: null,
       koulutusjaksot: [],
@@ -1020,6 +1020,10 @@
     get minSeuraavaKeskustelu(): Date {
       const now = new Date()
       return new Date(now.setMonth(now.getMonth() + 6))
+    }
+
+    get account() {
+      return store.getters['auth/account']
     }
 
     async onKouluttajaSubmit(value: Kayttaja, modal: BModal) {

--- a/src/forms/seurantajakso-haku-form.vue
+++ b/src/forms/seurantajakso-haku-form.vue
@@ -163,7 +163,7 @@
     })
     seurantajakso!: Seurantajakso | null
 
-    form: Seurantajakso = {
+    form: Partial<Seurantajakso> = {
       alkamispaiva: null,
       paattymispaiva: null,
       koulutusjaksot: [
@@ -235,7 +235,7 @@
     }
 
     addKoulutusjakso() {
-      this.form.koulutusjaksot.push({
+      this.form.koulutusjaksot?.push({
         id: null,
         nimi: null,
         muutOsaamistavoitteet: null,
@@ -249,7 +249,9 @@
     }
 
     deleteKoulutusjakso(index: number) {
-      Vue.delete(this.form.koulutusjaksot, index)
+      if (this.form.koulutusjaksot) {
+        Vue.delete(this.form.koulutusjaksot, index)
+      }
     }
 
     async onKoulutusjaksoSubmit(data: Koulutusjakso, params: { saving: boolean }, modal: BModal) {
@@ -279,7 +281,7 @@
         'submit',
         {
           ...this.form,
-          koulutusjaksot: this.form.koulutusjaksot.filter((koulutusjakso) => koulutusjakso.id)
+          koulutusjaksot: this.form.koulutusjaksot?.filter((koulutusjakso) => koulutusjakso.id)
         },
         this.params
       )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -123,7 +123,6 @@ export interface Tyoskentelyjakso {
   tyoskentelypaikka: Tyoskentelypaikka
   omaaErikoisalaaTukevaId?: number
   omaaErikoisalaaTukeva: Erikoisala | null
-  erikoistuvaLaakariId?: number
   tapahtumia?: boolean
   liitettyKoejaksoon?: boolean
   asiakirjat?: Asiakirja[]
@@ -663,7 +662,6 @@ export interface Paivakirjamerkinta {
   reflektio: string | null
   yksityinen: boolean
   aihekategoriat: PaivakirjaAihekategoria[]
-  erikoistuvaLaakariId?: number
   teoriakoulutus: Teoriakoulutus | null
 }
 
@@ -740,7 +738,10 @@ export type Seurantajakso = {
   jatkotoimetJaRaportointi?: string | null
   hyvaksytty?: boolean | null
   korjausehdotus?: string | null
-  erikoistuvaLaakari?: ErikoistuvaLaakari | null
+  erikoistuvanNimi: string | null
+  erikoistuvanErikoisalaNimi: string | null
+  erikoistuvanOpiskelijatunnus: string | null
+  erikoistuvanYliopistoNimi: string | null
   erikoistuvanAvatar?: string
   tallennettu?: string | null
   tila?: SeurantajaksoTila | null

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export type Opintooikeus = {
   yliopistoNimi: string
   erikoisalaId: number
   erikoisalaNimi: string
+  asetus: Asetus
 }
 
 export type ErikoistuvaLaakari = {
@@ -33,6 +34,7 @@ export type ErikoistuvaLaakari = {
   kayttajaId: number
   yliopisto: string
   opintooikeudet: Opintooikeus[]
+  opintooikeusKaytossaId: number
 }
 
 export interface UserAccount {
@@ -203,8 +205,8 @@ export type Vastuuhenkilo = {
 
 export interface KoulutussopimusLomake {
   erikoistuvanNimi: string
-  erikoistuvanErikoisala: string
-  erikoistuvanOpiskelijatunnus: string
+  erikoistuvanErikoisala?: string
+  erikoistuvanOpiskelijatunnus?: string
   erikoistuvanPuhelinnumero: string
   erikoistuvanSahkoposti: string
   erikoistuvanSyntymaaika: string
@@ -217,8 +219,8 @@ export interface KoulutussopimusLomake {
   koulutuspaikat: Koulutuspaikka[]
   lahetetty: boolean
   muokkauspaiva: string
-  opintooikeudenMyontamispaiva: string
-  opintooikeudenPaattymispaiva: string
+  opintooikeudenMyontamispaiva?: string
+  opintooikeudenPaattymispaiva?: string
   vastuuhenkilo?: Vastuuhenkilo
   erikoistuvanAllekirjoitusaika?: string
   yliopistot: Yliopisto[]
@@ -240,9 +242,9 @@ export type BlobDataResult = {
 }
 
 export interface AloituskeskusteluLomake {
-  erikoistuvanErikoisala: string
+  erikoistuvanErikoisala?: string
   erikoistuvanNimi: string
-  erikoistuvanOpiskelijatunnus: string
+  erikoistuvanOpiskelijatunnus?: string
   erikoistuvanSahkoposti: string
   erikoistuvanYliopisto: string
   erikoistuvanAvatar?: string

--- a/src/utils/opintooikeusResolver.ts
+++ b/src/utils/opintooikeusResolver.ts
@@ -1,0 +1,9 @@
+import { ErikoistuvaLaakari, Opintooikeus } from '@/types'
+
+export function resolveOpintooikeusKaytossa(
+  erikoistuvaLaakari: ErikoistuvaLaakari
+): Opintooikeus | undefined {
+  return erikoistuvaLaakari.opintooikeudet.find(
+    (o) => o.id === erikoistuvaLaakari.opintooikeusKaytossaId
+  )
+}

--- a/src/views/koejakso/erikoistuva/arviointilomake-aloituskeskustelu/arviointilomake-aloituskeskustelu-form.vue
+++ b/src/views/koejakso/erikoistuva/arviointilomake-aloituskeskustelu/arviointilomake-aloituskeskustelu-form.vue
@@ -293,8 +293,10 @@
     Kouluttaja,
     UserAccount,
     KoejaksonVaiheHyvaksyja,
-    KoejaksonVaiheButtonStates
+    KoejaksonVaiheButtonStates,
+    Opintooikeus
   } from '@/types'
+  import { resolveOpintooikeusKaytossa } from '@/utils/opintooikeusResolver'
 
   @Component({
     mixins: [validationMixin],
@@ -438,14 +440,18 @@
       this.form.tyotunnitViikossa = parseFloat(val.replace(',', '.'))
     }
 
+    get opintooikeusKaytossa(): Opintooikeus | undefined {
+      return resolveOpintooikeusKaytossa(this.account.erikoistuvaLaakari)
+    }
+
     get maxKoejaksonAlkamispaiva() {
       const dateFormat = 'yyyy-MM-dd'
-      if (!this.account.erikoistuvaLaakari.opintooikeudet[0]?.opintooikeudenPaattymispaiva) {
+      if (!this.opintooikeusKaytossa?.opintooikeudenPaattymispaiva) {
         return null
       }
 
       const opintooikeudenPaattymispaivaDate = new Date(
-        this.account.erikoistuvaLaakari.opintooikeudet[0]?.opintooikeudenPaattymispaiva
+        this.opintooikeusKaytossa.opintooikeudenPaattymispaiva
       )
       // Koejakson voi aloittaa viimeistään 6kk ennen määrä-aikaisen
       // opinto-oikeuden päättymispäivää, koska koejakson kesto on 6kk.
@@ -469,10 +475,7 @@
     get maxKoejaksonPaattymispaiva() {
       const dateFormat = 'yyyy-MM-dd'
       const koejaksonAlkamispaiva = this.form.koejaksonAlkamispaiva
-      if (
-        !this.account.erikoistuvaLaakari.opintooikeudet[0]?.opintooikeudenPaattymispaiva ||
-        !koejaksonAlkamispaiva
-      ) {
+      if (!this.opintooikeusKaytossa?.opintooikeudenPaattymispaiva || !koejaksonAlkamispaiva) {
         return null
       }
 
@@ -480,7 +483,7 @@
       // Koejakson kesto on maksimissaan 2 vuotta.
       koejaksonAlkamispaivaMaxDate.setFullYear(koejaksonAlkamispaivaMaxDate.getFullYear() + 2)
       const opintooikeudenPaattymispaivaDate = new Date(
-        this.account.erikoistuvaLaakari.opintooikeudet[0]?.opintooikeudenPaattymispaiva
+        this.opintooikeusKaytossa.opintooikeudenPaattymispaiva
       )
       // Mikäli maksimikesto 2 vuotta ylittää opinto-oikeuden päättymispäivän,
       // on maksimi päättymispäivä opinto-oikeuden päättymispäivä.
@@ -492,7 +495,7 @@
     }
 
     get opintooikeudenMyontamispaiva() {
-      return this.account.erikoistuvaLaakari.opintooikeudet[0]?.opintooikeudenMyontamispaiva
+      return this.opintooikeusKaytossa?.opintooikeudenMyontamispaiva
     }
 
     onLahikouluttajaSelect(lahikouluttaja: KoejaksonVaiheHyvaksyja) {
@@ -555,8 +558,8 @@
 
       // Asetetaan ei-muokattavien kenttien arvot
       this.form.erikoistuvanNimi = `${this.account.firstName} ${this.account.lastName}`
-      this.form.erikoistuvanOpiskelijatunnus = this.account.erikoistuvaLaakari.opintooikeudet[0]?.opiskelijatunnus
-      this.form.erikoistuvanErikoisala = this.account.erikoistuvaLaakari.opintooikeudet[0]?.erikoisalaNimi
+      this.form.erikoistuvanOpiskelijatunnus = this.opintooikeusKaytossa?.opiskelijatunnus
+      this.form.erikoistuvanErikoisala = this.opintooikeusKaytossa?.erikoisalaNimi
       this.form.erikoistuvanYliopisto = this.account.erikoistuvaLaakari.yliopisto
 
       if (!this.form.koejaksonAlkamispaiva) {

--- a/src/views/koejakso/erikoistuva/koulutussopimus/koulutussopimus-form.vue
+++ b/src/views/koejakso/erikoistuva/koulutussopimus/koulutussopimus-form.vue
@@ -245,10 +245,12 @@
     Kouluttaja,
     KoulutussopimusLomake,
     UserAccount,
-    Vastuuhenkilo
+    Vastuuhenkilo,
+    Opintooikeus
   } from '@/types'
   import { defaultKouluttaja, defaultKoulutuspaikka } from '@/utils/constants'
   import { formatList } from '@/utils/kouluttajaAndVastuuhenkiloListFormatter'
+  import { resolveOpintooikeusKaytossa } from '@/utils/opintooikeusResolver'
   import KouluttajaDetails from '@/views/koejakso/erikoistuva/koulutussopimus/kouluttaja-details.vue'
   import KoulutuspaikkaDetails from '@/views/koejakso/erikoistuva/koulutussopimus/koulutuspaikka-details.vue'
 
@@ -383,15 +385,17 @@
       return formatList(this, kouluttajat)
     }
 
+    get opintooikeusKaytossa(): Opintooikeus | undefined {
+      return resolveOpintooikeusKaytossa(this.account.erikoistuvaLaakari)
+    }
+
     get maxKoejaksonAlkamispaiva() {
       const dateFormat = 'yyyy-MM-dd'
-      if (!this.account.erikoistuvaLaakari.opintooikeudet[0]?.opintooikeudenPaattymispaiva) {
+      if (!this.opintooikeusKaytossa?.opintooikeudenPaattymispaiva) {
         return null
       }
 
-      const d = new Date(
-        this.account.erikoistuvaLaakari.opintooikeudet[0]?.opintooikeudenPaattymispaiva
-      )
+      const d = new Date(this.opintooikeusKaytossa.opintooikeudenPaattymispaiva)
       // Koejakson voi aloittaa viimeistään 6kk ennen määrä-aikaisen
       // opinto-oikeuden päättymispäivää, koska koejakson kesto on 6kk.
       d.setMonth(d.getMonth() - 6)
@@ -466,11 +470,11 @@
 
       // Asetetaan ei-muokattavien kenttien arvot
       this.form.erikoistuvanNimi = `${this.account.firstName} ${this.account.lastName}`
-      this.form.erikoistuvanOpiskelijatunnus = this.account.erikoistuvaLaakari.opintooikeudet[0]?.opiskelijatunnus
-      this.form.erikoistuvanErikoisala = this.account.erikoistuvaLaakari.opintooikeudet[0]?.erikoisalaNimi
+      this.form.erikoistuvanOpiskelijatunnus = this.opintooikeusKaytossa?.opiskelijatunnus
+      this.form.erikoistuvanErikoisala = this.opintooikeusKaytossa?.erikoisalaNimi
       this.form.erikoistuvanSyntymaaika = this.account.erikoistuvaLaakari.syntymaaika
       this.form.erikoistuvanYliopisto = this.account.erikoistuvaLaakari.yliopisto
-      this.form.opintooikeudenMyontamispaiva = this.account.erikoistuvaLaakari.opintooikeudet[0]?.opintooikeudenMyontamispaiva
+      this.form.opintooikeudenMyontamispaiva = this.opintooikeusKaytossa?.opintooikeudenMyontamispaiva
 
       // Asetetaan arvot kentille, jotka saatavissa erikoistuvan lääkärin tiedoista, mutta jotka
       // käyttäjä on saattanut yliajaa lomakkeen välitallennuksen yhteydessä. Kuitenkaan opinto-oikeuden

--- a/src/views/seurantakeskustelut/kouluttaja/seurantakeskustelut-kouluttaja.vue
+++ b/src/views/seurantakeskustelut/kouluttaja/seurantakeskustelut-kouluttaja.vue
@@ -54,7 +54,7 @@
             </template>
 
             <template #cell(erikoistuvanNimi)="data">
-              {{ data.item.erikoistuvaLaakari.nimi }}
+              {{ data.item.erikoistuvanNimi }}
             </template>
 
             <template #cell(seurantajakso)="data">
@@ -290,7 +290,7 @@
       if (this.hakutermi) {
         this.currentPage = 1
         return this.seurantajaksot?.filter((item: Seurantajakso) =>
-          item.erikoistuvaLaakari?.nimi.toLowerCase().includes(this.hakutermi.toLowerCase())
+          item.erikoistuvanNimi?.toLowerCase().includes(this.hakutermi.toLowerCase())
         )
       }
 


### PR DESCRIPTION
- Poista tyypeistä viittaus erikoistuvaan, koska erikoistujan tiedot luetaan pääasiassa erillisellä api-kutsulla saatavasta ErikoistuvaLaakari -tyyppisestä itemistä, eikä erikoistuvaLaakariId propertyyn viitata missään
- Lisää seurantajakso tyypille tarvittavat tiedot erikoistuvasta