### PR TITLE
UOELSA-998: Korjaa työskentelyjakson tyhjennys ja asettaminen

### DIFF
--- a/src/forms/koulutusjakso-form.vue
+++ b/src/forms/koulutusjakso-form.vue
@@ -276,7 +276,7 @@
         {
           ...this.form,
           tyoskentelyjaksot: this.form.tyoskentelyjaksot.filter(
-            (tyoskentelyjakso) => tyoskentelyjakso.id
+            (tyoskentelyjakso) => tyoskentelyjakso && tyoskentelyjakso.id
           )
         },
         this.params
@@ -290,7 +290,7 @@
     get tyoskentelyjaksotFiltered() {
       return ((this as any).tyoskentelyjaksotFormatted as Tyoskentelyjakso[]).filter(
         (tyoskentelyjakso) =>
-          !this.form.tyoskentelyjaksot?.find((t) => t.id === tyoskentelyjakso.id)
+          !this.form.tyoskentelyjaksot?.find((t) => t?.id === tyoskentelyjakso.id)
       )
     }
   }

--- a/src/mixins/tyoskentelyjakso.ts
+++ b/src/mixins/tyoskentelyjakso.ts
@@ -42,6 +42,16 @@ export default class TyoskentelyjaksoMixin extends Vue {
       this.tyoskentelyjaksot.push(tyoskentelyjakso)
       tyoskentelyjakso.label = tyoskentelyjaksoLabel(this, tyoskentelyjakso)
       this.form.tyoskentelyjakso = tyoskentelyjakso
+
+      if (this.form.tyoskentelyjaksot) {
+        for (const [index, value] of this.form.tyoskentelyjaksot.entries()) {
+          if (!value || !value.id) {
+            this.form.tyoskentelyjaksot[index] = tyoskentelyjakso
+            break
+          }
+        }
+      }
+
       this.onTyoskentelyjaksoSelect(tyoskentelyjakso)
       modal.hide('confirm')
       toastSuccess(this, this.$t('uusi-tyoskentelyjakso-lisatty'))


### PR DESCRIPTION
- Mikäli käyttäjä luo uuden työskentelyjakson, aseta se valituksi ensimmäiseen vapaana olevaan alasvetovalikkoon
- Mikäli molemmissa alasvetovalikoissa on jo valittu työskentelyjakso, lisää uusi jakso vain olemassaolevien vaihtoehtojen joukkoon