### PR TITLE
ELSASC-20: Korjaa käytönaloitus-näkymän reititysongelma

### DIFF
--- a/src/views/kayton-aloitus/kayton-aloitus.vue
+++ b/src/views/kayton-aloitus/kayton-aloitus.vue
@@ -43,7 +43,9 @@
       this.loading = true
       try {
         await putKaytonAloitusLomake(form)
-        this.$router.push({ name: 'etusivu' })
+
+        // Reitittää etusivulle. Jostain syystä push() ei toimi. ELSASC-20
+        this.$router.go(0)
       } catch (err) {
         this.loading = false
         const axiosError = err as AxiosError<ElsaError>

--- a/src/views/kayton-aloitus/kayton-aloitus.vue
+++ b/src/views/kayton-aloitus/kayton-aloitus.vue
@@ -17,6 +17,7 @@
 
   import { getErikoistuvaLaakari, putKaytonAloitusLomake } from '@/api/erikoistuva'
   import KaytonAloitusForm from '@/forms/kayton-aloitus-form.vue'
+  import store from '@/store'
   import { KaytonAloitusModel, Opintooikeus, ElsaError } from '@/types/index'
   import { sortByDateDesc } from '@/utils/date'
   import { toastFail } from '@/utils/toast'
@@ -43,9 +44,14 @@
       this.loading = true
       try {
         await putKaytonAloitusLomake(form)
+        const account = store.getters['auth/account']
 
-        // Reitittää etusivulle. Jostain syystä push() ei toimi. ELSASC-20
-        this.$router.go(0)
+        account.email = form.sahkoposti
+        if (form.opintooikeusId) {
+          account.erikoistuvaLaakari.opintooikeusKaytossaId = form.opintooikeusId
+        }
+
+        this.$router.push({ name: 'etusivu' })
       } catch (err) {
         this.loading = false
         const axiosError = err as AxiosError<ElsaError>


### PR DESCRIPTION
Testattu lokaalisti uuden käyttäjän käytön aloitus onnistuneesti. Kokeiltu sama myös virheellisillä tiedoilla (eri sähköpostiosoite, jo kannassa oleva spostiosoite) ongelmitta.

Juurisyytä (miksi push() ei toimi) en saanut selvitettyä. Tämä on workaround.