### PR TITLE
YEK-1532: YEK-koulutettavan tietojen katselun ja roolien korjauksia

### DIFF
--- a/src/api/yek-koulutettava.ts
+++ b/src/api/yek-koulutettava.ts
@@ -1,6 +1,8 @@
 import axios from 'axios'
 
 import {
+  AvoinAsia,
+  ErikoistumisenEdistyminen,
   LaillistamistiedotLomakeKoulutettava,
   Opintosuoritus,
   Tyoskentelyjakso,
@@ -72,4 +74,14 @@ export async function putYekValmistumispyynto(form: ValmistumispyyntoLomakeEriko
     headers: { 'Content-Type': 'multipart/form-data' },
     timeout: 120000
   })
+}
+
+export async function getErikoistumisenEdistyminen() {
+  const path = 'yek-koulutettava/etusivu/erikoistumisen-edistyminen'
+  return await axios.get<ErikoistumisenEdistyminen>(path)
+}
+
+export async function getAvoimetAsiat() {
+  const path = 'yek-koulutettava/etusivu/avoimet-asiat'
+  return await axios.get<AvoinAsia[]>(path)
 }

--- a/src/components/etusivu-cards/avoimet-asiat-yek-card.vue
+++ b/src/components/etusivu-cards/avoimet-asiat-yek-card.vue
@@ -66,7 +66,7 @@
 <script lang="ts">
   import { Component, Vue } from 'vue-property-decorator'
 
-  import { getAvoimetAsiat } from '@/api/erikoistuva'
+  import { getAvoimetAsiat } from '@/api/yek-koulutettava'
   import ElsaButton from '@/components/button/button.vue'
   import BCardSkeleton from '@/components/card/card.vue'
   import { AvoinAsia } from '@/types'

--- a/src/components/etusivu-cards/yek-koulutuksen-edistyminen-card.vue
+++ b/src/components/etusivu-cards/yek-koulutuksen-edistyminen-card.vue
@@ -90,7 +90,7 @@
   import { parseISO, differenceInMonths } from 'date-fns'
   import { Vue, Component } from 'vue-property-decorator'
 
-  import { getErikoistumisenEdistyminen } from '@/api/erikoistuva'
+  import { getErikoistumisenEdistyminen } from '@/api/yek-koulutettava'
   import ElsaArviointiasteikonTasoTooltipContent from '@/components/arviointiasteikon-taso/arviointiasteikon-taso-tooltip.vue'
   import ElsaArviointiasteikonTaso from '@/components/arviointiasteikon-taso/arviointiasteikon-taso.vue'
   import ElsaButton from '@/components/button/button.vue'

--- a/src/components/mobile-nav/mobile-nav.vue
+++ b/src/components/mobile-nav/mobile-nav.vue
@@ -17,7 +17,23 @@
         <font-awesome-icon :icon="['far', 'hospital']" fixed-width size="lg" />
         {{ $t('tyoskentelyjaksot') }}
       </b-nav-item>
+      <b-nav-item
+        v-if="$isYekKoulutettava()"
+        class="border-bottom"
+        :to="{ name: 'yektyoskentelyjaksot' }"
+      >
+        <font-awesome-icon :icon="['far', 'hospital']" fixed-width size="lg" />
+        {{ $t('tyoskentelyjaksot') }}
+      </b-nav-item>
       <b-nav-item v-if="$isErikoistuva()" class="border-bottom" :to="{ name: 'teoriakoulutukset' }">
+        <font-awesome-icon :icon="['fas', 'university']" fixed-width size="lg" />
+        {{ $t('teoriakoulutukset') }}
+      </b-nav-item>
+      <b-nav-item
+        v-if="$isYekKoulutettava()"
+        class="border-bottom"
+        :to="{ name: 'yekteoriakoulutukset' }"
+      >
         <font-awesome-icon :icon="['fas', 'university']" fixed-width size="lg" />
         {{ $t('teoriakoulutukset') }}
       </b-nav-item>
@@ -85,10 +101,22 @@
         <font-awesome-icon :icon="['far', 'file-alt']" fixed-width size="lg" />
         {{ $t('asiakirjat') }}
       </b-nav-item>
+      <b-nav-item v-if="$isYekKoulutettava()" class="border-bottom" :to="{ name: 'yekasiakirjat' }">
+        <font-awesome-icon :icon="['far', 'file-alt']" fixed-width size="lg" />
+        {{ $t('asiakirjat') }}
+      </b-nav-item>
       <b-nav-item
         v-if="$isErikoistuva() && !isImpersonated"
         class="border-bottom"
         :to="{ name: 'valmistumispyynto' }"
+      >
+        <font-awesome-icon :icon="['fas', 'trophy']" fixed-width size="lg" />
+        {{ $t('valmistumispyynto') }}
+      </b-nav-item>
+      <b-nav-item
+        v-if="$isYekKoulutettava() && !isImpersonated"
+        class="border-bottom"
+        :to="{ name: 'yekvalmistumispyynto' }"
       >
         <font-awesome-icon :icon="['fas', 'trophy']" fixed-width size="lg" />
         {{ $t('valmistumispyynto') }}
@@ -150,7 +178,7 @@
       <b-nav-item class="ml-6" link-classes="p-0 pt-1 pb-3" @click="logout()">
         {{ $t('kirjaudu-ulos') }}
       </b-nav-item>
-      <div v-if="$isErikoistuva() && opintooikeudet && opintooikeudet.length > 1" class="pb-2">
+      <div v-if="!account.impersonated && ($isErikoistuva() || $isYekKoulutettava())" class="pb-2">
         <hr class="p-0 m-0" />
         <div class="pl-2">
           <div class="dropdown-item dropdown-item__header mt-1 pb-1">
@@ -188,7 +216,7 @@
           </b-nav-item>
         </div>
       </div>
-      <div v-if="authorities && authorities.length > 1">
+      <div v-if="!account.impersonated && authorities && authorities.length > 1">
         <hr class="p-0 m-0" />
         <div class="dropdown-item dropdown-item__header mt-1 pb-1">
           <span class="font-weight-500">{{ $t('valitse-rooli') }}</span>
@@ -214,7 +242,7 @@
             </div>
           </div>
         </b-nav-item>
-        <b-nav-item @click="changeToYekKoulutettava">
+        <b-nav-item v-if="$hasYekRole()" @click="changeToYekKoulutettava">
           <div
             class="d-flex"
             :class="{

--- a/src/components/navbar/navbar.vue
+++ b/src/components/navbar/navbar.vue
@@ -50,7 +50,7 @@
             {{ $t('kirjaudu-ulos') }}
             <b-form ref="logoutForm" :action="logoutUrl" method="POST" />
           </b-dropdown-item>
-          <div v-if="$isErikoistuva() || $isYekKoulutettava()">
+          <div v-if="!account.impersonated && ($isErikoistuva() || $isYekKoulutettava())">
             <hr class="p-0 m-0" />
             <div class="dropdown-item dropdown-item__header mt-1 pb-1">
               <span class="font-weight-500">{{ $t('valitse-opinto-oikeus') }}</span>
@@ -86,7 +86,7 @@
               </div>
             </b-dropdown-item>
           </div>
-          <div v-if="authorities && authorities.length > 1">
+          <div v-if="!account.impersonated && authorities && authorities.length > 1">
             <hr class="p-0 m-0" />
             <div class="dropdown-item dropdown-item__header mt-1 pb-1">
               <span class="font-weight-500">{{ $t('valitse-rooli') }}</span>
@@ -112,7 +112,7 @@
                 </div>
               </div>
             </b-dropdown-item>
-            <b-dropdown-item @click="changeToYekKoulutettava">
+            <b-dropdown-item v-if="$hasYekRole()" @click="changeToYekKoulutettava">
               <div
                 class="d-flex"
                 :class="{

--- a/src/mixins/navbar.ts
+++ b/src/mixins/navbar.ts
@@ -139,18 +139,28 @@ export default class NavbarMixin extends Vue {
   async changeToErikoistuja() {
     if (this.$isErikoistuva()) return
     await vaihdaRooli(ELSA_ROLE.ErikoistuvaLaakari)
-    this.$router.go(0)
+    this.routeToEtusivu()
   }
 
   async changeToYekKoulutettava() {
     if (this.$isYekKoulutettava()) return
     await vaihdaRooli(ELSA_ROLE.YEKKoulutettava)
-    this.$router.go(0)
+    this.routeToEtusivu()
   }
 
   async changeToKouluttaja() {
     if (this.$isKouluttaja()) return
     await vaihdaRooli(ELSA_ROLE.Kouluttaja)
-    this.$router.go(0)
+    this.routeToEtusivu()
+  }
+
+  routeToEtusivu() {
+    if (this.$router.currentRoute.path.includes('etusivu')) {
+      this.$router.go(0)
+    } else {
+      this.$router.push({ name: 'etusivu' }).then(() => {
+        this.$router.go(0)
+      })
+    }
   }
 }

--- a/src/plugins/roles.ts
+++ b/src/plugins/roles.ts
@@ -14,6 +14,11 @@ export class RolesPlugin {
       return store.getters['auth/account'].activeAuthority === ELSA_ROLE.YEKKoulutettava
     }
 
+    vue.prototype.$hasYekRole = (): boolean => {
+      const authorities = store.getters['auth/account'].authorities
+      return authorities.includes(ELSA_ROLE.YEKKoulutettava)
+    }
+
     vue.prototype.$isKouluttaja = (): boolean => {
       return store.getters['auth/account'].activeAuthority === ELSA_ROLE.Kouluttaja
     }
@@ -55,6 +60,7 @@ declare module 'vue/types/vue' {
     $isTekninenPaakayttaja: Function
     $isVirkailija: Function
     $hasKouluttajaRole: Function
+    $hasYekRole: Function
   }
 }
 

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -59,7 +59,10 @@ const auth: Module<any, any> = {
       commit('authRequest')
       try {
         const { data } = await api.getKayttaja()
-        if (data.authorities.includes(ELSA_ROLE.ErikoistuvaLaakari)) {
+        if (
+          data.authorities.includes(ELSA_ROLE.ErikoistuvaLaakari) ||
+          data.authorities.includes(ELSA_ROLE.YEKKoulutettava)
+        ) {
           data.erikoistuvaLaakari = (await getErikoistuvaLaakari()).data
         }
         if (data.impersonated) {


### PR DESCRIPTION
- Mobiilinavigaatio YEK-koulutettavalle
- Opinto-oikeuksien näkyminen samalla tavalla työpöytä ja mobiilinavigaatiossa
- Impersonoidun käyttäjän ylimääräisten tietojen piilottaminen
- Roolin vaihdon ohjaus etusivulle (nykyisen näkymän sijaan, uudella roolilla ei ehkä ole samaa sivua)
- YEK-koulutettavan tietojen hakeminen jos ei muita opinto-oikeuksia eikä erikoistuvan roolia