### PR TITLE
Github actions käyttöön

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,150 @@
+name: Frontend CI
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+    tags-ignore:
+      - '*'
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn
+      - name: Lint
+        run: yarn lint
+      - name: Test
+        run: yarn test:unit
+      - name: Generate thirdparty
+        run: yarn generate-thirdparty
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn
+      - name: Build
+        run: yarn build --mode production-test
+      - name: Store dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: ElsaFrontendApp
+          path: dist
+
+  deploy-dev:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    environment: development
+
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: ElsaFrontendApp
+          path: dist
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/GithubActionsRole
+          aws-region: eu-west-1
+      - name: Deploy static site to S3 bucket
+        run: aws s3 sync dist s3://kehitys.elsapalvelu.fi/ --delete
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/*"
+
+  deploy-staging:
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/heads/release/')
+    environment: staging
+
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: ElsaFrontendApp
+          path: dist
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/GithubActionsRole
+          aws-region: eu-west-1
+      - name: Deploy static site to S3 bucket
+        run: aws s3 sync dist s3://testi.elsapalvelu.fi/ --delete
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/*"
+
+  build-prod:
+    runs-on: ubuntu-latest
+    needs: test
+    if: startsWith(github.ref, 'refs/heads/release/')
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn
+      - name: Build
+        run: yarn build
+      - name: Store dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: ElsaFrontendAppProd
+          path: dist
+
+  deploy-prod:
+    runs-on: ubuntu-latest
+    needs: build-prod
+    if: startsWith(github.ref, 'refs/heads/release/')
+    environment: production
+
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: ElsaFrontendAppProd
+          path: dist
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/GithubActionsRole
+          aws-region: eu-west-1
+      - name: Deploy static site to S3 bucket
+        run: aws s3 sync dist s3://elsapalvelu.fi/ --delete
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
Github Actions hyötyjä:

- Ei rajoituksia montako samanaikaista runneria
- Ajot näkee suoraan githubista
- Ympäristökohtaisia asetuksia ja muuttujia voidaan hallitan githubista
- Nopeampi

Muita parannuksia:

- Github OIDC käyttöön jolloin ei tarvita erillisiä AWS käyttäjiä CI:lle vaan githubia varten tehdään aina väliaikainen pääsy

Huomioita:

- Toistaiseksi jätetty azure devops konfiguraatio myös paikalleen, voidaan ottaa pois jossain kohti jos actions toimii vakaasti
- Releasen yhteydessä täytyy seurata meneekö deploy läpi