### PR TITLE
ELSA-874 valmistumispyynnön hyväksyntä tyhjentää käyttäjän tietoja

### DIFF
--- a/src/components/valmistumispyynnot-list/yek-valmistumispyynnot-list.vue
+++ b/src/components/valmistumispyynnot-list/yek-valmistumispyynnot-list.vue
@@ -234,7 +234,6 @@
     }
 
     get content() {
-      console.log(this.valmistumispyynnot)
       return this.valmistumispyynnot?.content
     }
 

--- a/src/views/valmistumispyynnot-yek/vastuuhenkilo/valmistumispyynnon-hyvaksynta-yek.vue
+++ b/src/views/valmistumispyynnot-yek/vastuuhenkilo/valmistumispyynnon-hyvaksynta-yek.vue
@@ -551,16 +551,18 @@
       try {
         this.sending = true
         if (this.valmistumispyynto.id) {
+          const puhelinnumero = this.form.puhelinnumero
+          const sahkoposti = this.form.sahkoposti
           this.form = (
             await putValmistumispyyntoHyvaksynta({
               id: this.valmistumispyynto.id,
-              puhelinnumero: this.form.puhelinnumero,
-              sahkoposti: this.form.sahkoposti
+              puhelinnumero,
+              sahkoposti
             })
           ).data
           const account = store.getters['auth/account']
-          account.email = this.form.sahkoposti
-          account.phoneNumber = this.form.puhelinnumero
+          account.email = sahkoposti
+          account.phoneNumber = puhelinnumero
           this.$emit('skipRouteExitConfirm', true)
           toastSuccess(this, this.$t('valmistumispyynto-hyvaksynta-lahetys-onnistui'))
           this.$router.replace({ name: 'valmistumispyynnot', hash: '#yek' })

--- a/src/views/valmistumispyynnot/vastuuhenkilo/valmistumispyynnon-hyvaksynta.vue
+++ b/src/views/valmistumispyynnot/vastuuhenkilo/valmistumispyynnon-hyvaksynta.vue
@@ -683,16 +683,18 @@
       try {
         this.sending = true
         if (this.valmistumispyynto.id) {
+          const puhelinnumero = this.form.puhelinnumero
+          const sahkoposti = this.form.sahkoposti
           this.form = (
             await putValmistumispyyntoHyvaksynta({
               id: this.valmistumispyynto.id,
-              puhelinnumero: this.form.puhelinnumero,
-              sahkoposti: this.form.sahkoposti
+              puhelinnumero,
+              sahkoposti
             })
           ).data
           const account = store.getters['auth/account']
-          account.email = this.form.sahkoposti
-          account.phoneNumber = this.form.puhelinnumero
+          account.email = sahkoposti
+          account.phoneNumber = puhelinnumero
           this.$emit('skipRouteExitConfirm', true)
           toastSuccess(this, this.$t('valmistumispyynto-hyvaksynta-lahetys-onnistui'))
           this.$router.replace({ name: 'valmistumispyynnot' })


### PR DESCRIPTION
Korjattu ongelma, jossa vastuuhenkilön puhelinnumero ja sähköposti tyhjentyivät, kun valmistumispyyntö oli hyväksytty. Ongelma ei suoraan tyhjentänyt tietokannasta mitään, vaan liittyi siihen, että istuntontoon tallennetut tiedot päivitettiin lomakkeen tiedoilla, mutta lomakkeen tiedoiksi muokattiin putValmistumispyyntöHyväksyntä vastaus, jolloin tarvittavia tietoja ei ollut enää saatavilla, vaan tiedoiksi tuli undefined. Mahdollisesti vastuuhenkilö on mennyt hyväksynnän jälkeen suoraan seuraavaan valmistumispyyntöön ja hyväksynyt sen, jolloin on voinut päätyä tilanteeseen, että lomakkeen tietoihin olisi puh ja email kenttiin päätynyt undefined (tosin ei pitäisi mennä validoinnista läpi) ja seuraava tallennus sitten tallentanut nämä tietokantaan.