### PR TITLE
ELSA-885: Korjattu virheellinen validoinnin nimi

### DIFF
--- a/src/views/profiili/omat-tiedot.vue
+++ b/src/views/profiili/omat-tiedot.vue
@@ -352,7 +352,7 @@
             required,
             email
           },
-          confirmEmail: {
+          emailConfirm: {
             emailConfirmed: () => {
               return this.needEmailConfirm ? this.form.email === this.confirmEmailValue : true
             }


### PR DESCRIPTION
Validoinneissa oli emailConfirm nimetty virheellisesti confirmEmailiksi